### PR TITLE
Refactor README

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_network.md
+++ b/.github/ISSUE_TEMPLATE/request_network.md
@@ -1,13 +1,14 @@
 ---
 name: Request new network
 about: Request to add the deployment information for a new network
-
 ---
+
 ## Network information
+
 - Name:
 - ChainId:
 - RPC http/s address:
-- Link to https://chainlist.org/ 
+- Link to https://chainlist.org/
 - (Optional) Blockexplorer:
-- [] I have run `RPC='http://my-rpc-address' yarn estimate`
-- [] I have sent `requiredFunds` to `0xE1CB04A0fA36DdD16a06ea828007E35e1a3cBC37`
+- [ ] I have run `RPC='http://my-rpc-address' yarn estimate`
+- [ ] I have sent `requiredFunds` to `0xE1CB04A0fA36DdD16a06ea828007E35e1a3cBC37`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The original library used a presigned transaction without a chain id to allow de
 
 ## How to get the singleton deployed to your network
 
-As the singleton is EIP155 protected, we need to sign the singleton for your network. But some requisites must be met before we do that, the most important one is having funds on the deployer so we can deploy the contract.
+As the singleton is deployed with an EIP155 transaction, we need to sign the deployment transaction for your network. But some prerequisites must be met before that, and the most important one is having funds on the deployer so we can deploy the contract.
 
 - Make sure your network is on https://chainlist.org/ . We will not accept networks not present there.
 - Install dependencies running `yarn`.

--- a/README.md
+++ b/README.md
@@ -4,28 +4,19 @@ Singleton factory used by Safe related contracts based on https://github.com/Ara
 
 The original library used a presigned transaction without a chain id to allow deployment on different chains. Some chains do not allow such transactions to be submitted (e.g. Celo and Avalanche) therefore this repository will provide the same factory that can be deployed via a presigned transaction that includes the chain id. The key that is used to sign is controlled by the Safe team.
 
-# Adding new networks
+# User documentation
 
-To add support for new networks the same key used for the existing networks should be used to generate a presigned transaction for a new network. To request support for a new network please open a [new issue](https://github.com/safe-global/safe-singleton-factory/issues/new/choose).
+## How to get singleton deployed for you network
 
-To generate the deployment data for a new network the following steps are necessary:
+As the singleton is EIP155 protected, we need to sign the singleton for your network. But some requisites must be met before we do that, the most important one is having funds on the deployer so we can deploy the contract.
 
-- Set `RPC` in the `.env` file for the new network
-- Estimate transaction params via `yarn estimate`
+- Make sure your network is on https://chainlist.org/ . We will not accept networks not present there.
+- Install dependencies running `yarn`.
+- Estimate the contract deployment: `RPC='http://my-rpc-address' yarn estimate`.
+- Send `requiredFunds` to the deployer address `0xE1CB04A0fA36DdD16a06ea828007E35e1a3cBC37`.
+- Open a PR and we will deploy the singleton contract.
 
-- Set `MNEMONIC` in the `.env` file
-- Run `yarn compile <chain_id> [--gasPrice <overwrite_gas_price>] [--gasLimit <overwrite_gas_limit>]`
-
-To do `estimate` and `compile` steps together:
-
-- Run `yarn estimate-compile ["$RPC"]`
-
-# For zkSync
-
-- Set `MNEMONIC` or `PK` in the `.env` file
-- Run `yarn compile:zk`
-
-# Expected Addresses
+## Expected Addresses
 
 For all networks the same deployer key is used. The address for this key is `0xE1CB04A0fA36DdD16a06ea828007E35e1a3cBC37`.
 
@@ -34,3 +25,27 @@ This results in the address for the factory to be `0x914d7Fec6aaC8cd542e72Bca78B
 For zkSync based networks the same deployer is used and expected factory address is `0xaECDbB0a3B1C6D1Fe1755866e330D82eC81fD4FD`.
 
 Note: For zkSync the factory is deployed using the `create2` method of the system deployer using the zero hash (`0x0000000000000000000000000000000000000000000000000000000000000000`).
+
+# Safe developers documentation
+
+## Adding new networks
+
+To generate the deployment data for a new network the following steps are necessary:
+
+- Set `RPC` in the `.env` file for the new network.
+- Set `MNEMONIC` in the `.env` file.
+- Estimate transaction params via `yarn estimate`
+- Run `yarn compile <chain_id> [--gasPrice <overwrite_gas_price>] [--gasLimit <overwrite_gas_limit>]`
+
+To do `estimate` and `compile` steps together:
+
+- Run `yarn estimate-compile ["$RPC"]`
+
+To submit a transaction after the deployment data is created:
+
+- Run `yarn submit`
+
+## For zkSync
+
+- Set `MNEMONIC` or `PK` in the `.env` file
+- Run `yarn compile:zk`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The original library used a presigned transaction without a chain id to allow de
 
 # User documentation
 
-## How to get singleton deployed for you network
+## How to get the singleton deployed to your network
 
 As the singleton is EIP155 protected, we need to sign the singleton for your network. But some requisites must be met before we do that, the most important one is having funds on the deployer so we can deploy the contract.
 


### PR DESCRIPTION
- Split user documentation and Safe devs documentation, as that could be misleading
- Add information about the new process (sending funds to the deployer)
- Fix typo on Github issue template
