### PR TITLE
Adjust GitHub Workflow to Use Labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_chain.yml
+++ b/.github/ISSUE_TEMPLATE/new_chain.yml
@@ -1,6 +1,7 @@
 name: Request factory deployment to a new chain
 description: Template to request a factory deployment to a new chain
 title: "[New chain]: "
+labels: ["new-chain"]
 body:
   - type: markdown
     attributes:

--- a/.github/scripts/validate_new_chain_request.sh
+++ b/.github/scripts/validate_new_chain_request.sh
@@ -76,7 +76,7 @@ fi
 
 rpc_url="$(trim "$rpc_url")"
 echo "Extracted RPC url: $rpc_url. Trying to get the chain id..."
-response=$(curl "$rpc_url" --location --header \
+response=$(curl -s "$rpc_url" --location --header \
     'Content-Type: application/json' --data '{
                           "jsonrpc": "2.0",
                           "method": "eth_chainId",
@@ -93,7 +93,7 @@ else
 fi
 
 
-factory_code=$(curl "$rpc_url" --location --header \
+factory_code=$(curl -s "$rpc_url" --location --header \
   'Content-Type: application/json' --data '{
                 "jsonrpc": "2.0",
                 "method": "eth_getCode",
@@ -112,7 +112,7 @@ fi
 echo "$chain_id from the RPC URL is valid. Checking the chain in chainlist..."
 chainlist_url="https://raw.githubusercontent.com/ethereum-lists/chains/master/_data/chains/eip155-$chain_id.json"
 
-chainlist_status_code=$(trim "$(curl -LI "$chainlist_url" -o /dev/null -w '%{http_code}\n' -s)")
+chainlist_status_code=$(trim "$(curl -sLI "$chainlist_url" -o /dev/null -w '%{http_code}\n' -s)")
 
 if [ "$chainlist_status_code" == "404" ]; then
   echo "Chain $chain_id is not in chainlist."
@@ -139,7 +139,7 @@ json_request='[
     }
 ]'
 
-response=$(curl "$rpc_url" --location --header 'Content-Type: application/json' --data "$json_request")
+response=$(curl -s "$rpc_url" --location --header 'Content-Type: application/json' --data "$json_request")
 
 if jq -e . >/dev/null 2>&1 <<< "$response"; then
   gas_price=$(jq -r '.[0].result' <<< "$response")
@@ -157,7 +157,7 @@ if jq -e . >/dev/null 2>&1 <<< "$response"; then
 
   echo "Expected pre-fund: $expected_prefund"
 
-  deployer_address_balance=$(curl "$rpc_url" --location --header \
+  deployer_address_balance=$(curl -s "$rpc_url" --location --header \
   'Content-Type: application/json' --data '{
                 "jsonrpc": "2.0",
                 "method": "eth_getBalance",

--- a/.github/workflows/prepare-transaction.yml
+++ b/.github/workflows/prepare-transaction.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   prepareTransaction:
+    if: ${{ contains(github.event.issue.labels.*.name, 'new-chain') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,3 +36,13 @@ jobs:
           COMMENT_OUTPUT: ${{ env.COMMENT_OUTPUT }}
         run: |
           gh issue comment "$NUMBER" --repo "$REPO" --body "$COMMENT_OUTPUT" --edit-last || gh issue comment "$NUMBER" --repo "$REPO" --body "$COMMENT_OUTPUT"
+          gh issue edit "$NUMBER" --repo "$REPO" "$LABEL_OPERATION" ready-to-deploy
+
+  # Workflows where all jobs are skipped are counted as "failed". In order to
+  # work around this, always execute a dummy job regardless of whether or not
+  # the `new-chain` tag is set.
+  alwaysExecuted:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "always executed"


### PR DESCRIPTION
Fixes #438

This PR uses two new labels to signal statuses for new chain issues in the repository:

- `new-chain` label is used when a "new chain" issue is created, this is used for filtering by the GH workflow to not spam unrelated issues such as the one fixed by this PR with failure messages
- `ready-to-deploy` label which is used to indicate that the GH workflow checks on the new chain succeeded, and that it is ready to deploy. This is a helpful precursor to facilitating other helper scripts that run the `estimate` and `compile` NPM scripts for all ready chains