### PR TITLE
Install jq 1.7 to handle large gwei balance

### DIFF
--- a/.github/workflows/prepare-transaction.yml
+++ b/.github/workflows/prepare-transaction.yml
@@ -13,6 +13,12 @@ jobs:
     if: ${{ contains(github.event.issue.labels.*.name, 'new-chain') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v2.1.0
+        with:
+          version: '1.7'
+          force: true
+            
       - uses: actions/checkout@v4
         with:
           sparse-checkout: |


### PR DESCRIPTION
Related to https://github.com/safe-global/safe-singleton-factory/issues/586 .

Many factory deployment actions fail because too many ethers are sent to the bot's account. For example, I sent 10^19 gwei in https://github.com/safe-global/safe-singleton-factory/actions/runs/10001624545/job/27645578947 , and the bash script thinks I have -8446744073709551616 gwei, where 10^19 + 8446744073709551616 == 2^64. The reason may be...
https://github.com/safe-global/safe-singleton-factory/blob/4da1be4b62cdafca027d940b78f9994677277f6c/.github/scripts/validate_new_chain_request.sh#L183
The bash tool jq cannot handle large numbers correctly. 
https://github.com/jqlang/jq/issues/1959#issuecomment-1712175933
jq 1.7 fixed the problem
https://github.com/actions/runner-images/issues/9550#issuecomment-2017696786
But github actions is not willing to upgrade jq to 1.7 .

**I have not tested this pull request.**