### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @safe-global/safe-protocol
+* @safe-fndn/contracts


### PR DESCRIPTION
We migrated orgs, and have new team names, so fix this in the `CODEOWNERS` file.