### PR TITLE
Add permissions for contents and issues in workflow

### DIFF
--- a/.github/workflows/prepare-transaction.yml
+++ b/.github/workflows/prepare-transaction.yml
@@ -8,6 +8,10 @@ env:
   NUMBER: ${{ github.event.issue.number }}
   REPO: ${{ github.repository }}
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   prepareTransaction:
     if: ${{ contains(github.event.issue.labels.*.name, 'new-chain') }}


### PR DESCRIPTION
This PR adds required permissions to the GitHub action that checks Safe singleton requests to see if they are ready to deploy.