### PR TITLE
Add OpenLedger Mainnet support(opstack based)

### DIFF
--- a/artifacts/1612/deployment.json
+++ b/artifacts/1612/deployment.json
@@ -1,0 +1,7 @@
+{
+	"gasPrice": 0,
+	"gasLimit": 0,
+	"signerAddress": "0x0000000000000000000000000000000000000000",
+	"transaction": "0x",
+	"address": "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7"
+}


### PR DESCRIPTION
This PR adds support for the OpenLedger Mainnet, an OP Stack-based L2 network, to the Safe Singleton Factory.

Details:

Chain Name: OpenLedger Mainnet
Chain ID: 1612
RPC URL: https://rpc.openledger.xyz/
Explorer: https://scan.openledger.xyz/
Token Symbol: OPEN

Network:
OP Stack (L2)
Settled on Ethereum (Chain ID: 1)
Chainlist: https://chainlist.org/chain/1612