### PR TITLE
Add CLA Agreement to Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+
+---
+
+## CLA signature
+
+With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
+.github/PULL_REQUEST_TEMPLATE.md
 package.json
 package-lock.json


### PR DESCRIPTION
The `PULL_REQUEST_TEMPLATE.md` was ignored as the additional newline at the start of the file is intentional but not allowed by `prettier`.