### PR TITLE
Add Whitechain Sepolia

### DIFF
--- a/artifacts/1874/deployment.json
+++ b/artifacts/1874/deployment.json
@@ -1,0 +1,7 @@
+{
+	"gasPrice": 0,
+	"gasLimit": 0,
+	"signerAddress": "0x0000000000000000000000000000000000000000",
+	"transaction": "0x",
+	"address": "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7"
+}


### PR DESCRIPTION
This PR adds support for the Whitechain Sepolia, an OP Stack-based L2 network.

Fixes #1420 

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://docs.safefoundation.org/cla).
